### PR TITLE
Moved Uncompress to own package for easier import

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"os"
 
-	dejsonlz4 "github.com/giulianopz/go-dejsonlz4"
+	"github.com/giulianopz/go-dejsonlz4/jsonlz4"
 )
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 		panic(err)
 	}
 
-	outputData, err := dejsonlz4.Uncompress(inputData)
+	outputData, err := jsonlz4.Uncompress(inputData)
 	if err != nil {
 		panic(err)
 	}

--- a/jsonlz4/uncompress.go
+++ b/jsonlz4/uncompress.go
@@ -1,4 +1,4 @@
-package main
+package jsonlz4
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/giulianopz/go-dejsonlz4/jsonlz4"
 )
 
 const hyphenSign = "-"
@@ -53,7 +55,7 @@ func main() {
 		inputData = bs
 	}
 
-	outputData, err := Uncompress(inputData)
+	outputData, err := jsonlz4.Uncompress(inputData)
 	if err != nil {
 		printErr(err)
 	}


### PR DESCRIPTION
While importing this the way described I'm getting `import "github.com/giulianopz/go-dejsonlz4" is a program, not an importable package`. To help prevent that and allow for easier importing an usage in other projects I've moved the decoding logic itself to it's own package.  
This now removes that build error while allowing importation using the following once it's live
```go
import "github.com/giulianopz/go-dejsonlz4/jsonlz4"
```